### PR TITLE
Added|Fixed: Extract Superclass from FieldInvokeResult and

### DIFF
--- a/termux-shared/src/main/java/com/termux/shared/reflection/InvokeResult.java
+++ b/termux-shared/src/main/java/com/termux/shared/reflection/InvokeResult.java
@@ -1,0 +1,12 @@
+package com.termux.shared.reflection;
+
+/** Class that represents result of invoking of something */
+public abstract class InvokeResult {
+    public boolean success;
+    public Object value;
+
+    InvokeResult(boolean success, Object value) {
+        this.value = success;
+        this.value = value;
+    }
+}

--- a/termux-shared/src/main/java/com/termux/shared/reflection/ReflectionUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/reflection/ReflectionUtils.java
@@ -64,15 +64,12 @@ public class ReflectionUtils {
 
 
     /** Class that represents result of invoking a field. */
-    public static class FieldInvokeResult {
-        public boolean success;
-        public Object value;
-
+    public static class FieldInvokeResult extends InvokeResult {
         FieldInvokeResult(boolean success, Object value) {
-            this.value = success;
-            this.value = value;
+            super(success, value);
         }
     }
+
 
     /**
      * Get a value for a {@link Field} of an object for the specified class.
@@ -161,13 +158,9 @@ public class ReflectionUtils {
 
 
     /** Class that represents result of invoking a method that has a non-void return type. */
-    public static class MethodInvokeResult {
-        public boolean success;
-        public Object value;
-
+    public static class MethodInvokeResult extends InvokeResult{
         MethodInvokeResult(boolean success, Object value) {
-            this.value = success;
-            this.value = value;
+            super(success, value);
         }
     }
 


### PR DESCRIPTION
MethodInvokeResult

Since FieldInvokeResult and MethodInvokeResult class has a lot in
common, extracting them as superclass seems to be more useful for adding
other "InvokeResult" classes in the future.