### PR TITLE
refactor: extract class `DebuggingPreferencesDataStore.java` from `DebuggingPreferencesFragment.java` and make new package `datastore`

### DIFF
--- a/app/src/main/java/com/termux/app/datastore/termux/DebuggingPreferencesDataStore.java
+++ b/app/src/main/java/com/termux/app/datastore/termux/DebuggingPreferencesDataStore.java
@@ -1,0 +1,98 @@
+package com.termux.app.datastore.termux;
+
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+import androidx.preference.PreferenceDataStore;
+
+import com.termux.shared.termux.settings.preferences.TermuxAppSharedPreferences;
+
+public class DebuggingPreferencesDataStore extends PreferenceDataStore {
+
+    private final Context mContext;
+    private final TermuxAppSharedPreferences mPreferences;
+
+    private static DebuggingPreferencesDataStore mInstance;
+
+    private DebuggingPreferencesDataStore(Context context) {
+        mContext = context;
+        mPreferences = TermuxAppSharedPreferences.build(context, true);
+    }
+
+    public static synchronized DebuggingPreferencesDataStore getInstance(Context context) {
+        if (mInstance == null) {
+            mInstance = new DebuggingPreferencesDataStore(context);
+        }
+        return mInstance;
+    }
+
+
+
+    @Override
+    @Nullable
+    public String getString(String key, @Nullable String defValue) {
+        if (mPreferences == null) return null;
+        if (key == null) return null;
+
+        switch (key) {
+            case "log_level":
+                return String.valueOf(mPreferences.getLogLevel());
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public void putString(String key, @Nullable String value) {
+        if (mPreferences == null) return;
+        if (key == null) return;
+
+        switch (key) {
+            case "log_level":
+                if (value != null) {
+                    mPreferences.setLogLevel(mContext, Integer.parseInt(value));
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+
+
+    @Override
+    public void putBoolean(String key, boolean value) {
+        if (mPreferences == null) return;
+        if (key == null) return;
+
+        switch (key) {
+            case "terminal_view_key_logging_enabled":
+                mPreferences.setTerminalViewKeyLoggingEnabled(value);
+                break;
+            case "plugin_error_notifications_enabled":
+                mPreferences.setPluginErrorNotificationsEnabled(value);
+                break;
+            case "crash_report_notifications_enabled":
+                mPreferences.setCrashReportNotificationsEnabled(value);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public boolean getBoolean(String key, boolean defValue) {
+        if (mPreferences == null) return false;
+        switch (key) {
+            case "terminal_view_key_logging_enabled":
+                return mPreferences.isTerminalViewKeyLoggingEnabled();
+            case "plugin_error_notifications_enabled":
+                return mPreferences.arePluginErrorNotificationsEnabled(false);
+            case "crash_report_notifications_enabled":
+                return mPreferences.areCrashReportNotificationsEnabled(false);
+            default:
+                return false;
+        }
+    }
+
+}

--- a/app/src/main/java/com/termux/app/fragments/settings/termux/DebuggingPreferencesFragment.java
+++ b/app/src/main/java/com/termux/app/fragments/settings/termux/DebuggingPreferencesFragment.java
@@ -13,6 +13,7 @@ import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 
 import com.termux.R;
+import com.termux.app.datastore.termux.DebuggingPreferencesDataStore;
 import com.termux.shared.termux.settings.preferences.TermuxAppSharedPreferences;
 import com.termux.shared.logger.Logger;
 
@@ -64,92 +65,4 @@ public class DebuggingPreferencesFragment extends PreferenceFragmentCompat {
 
 }
 
-class DebuggingPreferencesDataStore extends PreferenceDataStore {
 
-    private final Context mContext;
-    private final TermuxAppSharedPreferences mPreferences;
-
-    private static DebuggingPreferencesDataStore mInstance;
-
-    private DebuggingPreferencesDataStore(Context context) {
-        mContext = context;
-        mPreferences = TermuxAppSharedPreferences.build(context, true);
-    }
-
-    public static synchronized DebuggingPreferencesDataStore getInstance(Context context) {
-        if (mInstance == null) {
-            mInstance = new DebuggingPreferencesDataStore(context);
-        }
-        return mInstance;
-    }
-
-
-
-    @Override
-    @Nullable
-    public String getString(String key, @Nullable String defValue) {
-        if (mPreferences == null) return null;
-        if (key == null) return null;
-
-        switch (key) {
-            case "log_level":
-                return String.valueOf(mPreferences.getLogLevel());
-            default:
-                return null;
-        }
-    }
-
-    @Override
-    public void putString(String key, @Nullable String value) {
-        if (mPreferences == null) return;
-        if (key == null) return;
-
-        switch (key) {
-            case "log_level":
-                if (value != null) {
-                    mPreferences.setLogLevel(mContext, Integer.parseInt(value));
-                }
-                break;
-            default:
-                break;
-        }
-    }
-
-
-
-    @Override
-    public void putBoolean(String key, boolean value) {
-        if (mPreferences == null) return;
-        if (key == null) return;
-
-        switch (key) {
-            case "terminal_view_key_logging_enabled":
-                    mPreferences.setTerminalViewKeyLoggingEnabled(value);
-                break;
-            case "plugin_error_notifications_enabled":
-                mPreferences.setPluginErrorNotificationsEnabled(value);
-                break;
-            case "crash_report_notifications_enabled":
-                mPreferences.setCrashReportNotificationsEnabled(value);
-                break;
-            default:
-                break;
-        }
-    }
-
-    @Override
-    public boolean getBoolean(String key, boolean defValue) {
-        if (mPreferences == null) return false;
-        switch (key) {
-            case "terminal_view_key_logging_enabled":
-                return mPreferences.isTerminalViewKeyLoggingEnabled();
-            case "plugin_error_notifications_enabled":
-                return mPreferences.arePluginErrorNotificationsEnabled(false);
-            case "crash_report_notifications_enabled":
-                return mPreferences.areCrashReportNotificationsEnabled(false);
-            default:
-                return false;
-        }
-    }
-
-}


### PR DESCRIPTION
`DebuggingPreferencesFragment.java` have two class. Extracting `DebuggingPreferencesDataStore.java` help maintain adherence to the Single Responsibility Principle. and make `datastore` package.