### PR TITLE
Changed: Delete `localVariableList` in `getLogString()` and

### DIFF
--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/LocalSocketRunConfig.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/LocalSocketRunConfig.java
@@ -230,11 +230,9 @@ public class LocalSocketRunConfig implements Serializable {
     public String getLogString() {
         StringBuilder logString = new StringBuilder();
 
-        List<Pair<String, Object>> logVariableList = getLogVariableList();
-
         logString.append(mTitle).append(" Socket Server Run Config:");
         
-        for(Pair<String, Object> logVar: logVariableList) {
+        for(Pair<String, Object> logVar: getLogVariableList()) {
             logString.append("\n").append(Logger.getSingleLineLogStringEntry(logVar.first, logVar.second, "-"));
         }
 
@@ -257,11 +255,9 @@ public class LocalSocketRunConfig implements Serializable {
     public String getMarkdownString() {
         StringBuilder markdownString = new StringBuilder();
 
-        List<Pair<String, Object>> logVariableList = getLogVariableList();
-
         markdownString.append("## ").append(mTitle).append(" Socket Server Run Config");
 
-        for(Pair<String, Object> logVar: logVariableList) {
+        for(Pair<String, Object> logVar: getLogVariableList()) {
             markdownString.append("\n").append(MarkdownUtils.getSingleLineMarkdownStringEntry(logVar.first, logVar.second, "-"));
         }
 


### PR DESCRIPTION
`getMarkDownString()` in `LocalSocketRunConfig.java`

Replaced calling `getLocalVariableList()` directly, instead of declaring
local variable.