### PR TITLE
Added: Add `configureTermuxPreference.java` for `RootPreferencesFragment.java`

### DIFF
--- a/app/src/main/java/com/termux/app/fragments/settings/configureTermuxPreference.java
+++ b/app/src/main/java/com/termux/app/fragments/settings/configureTermuxPreference.java
@@ -1,0 +1,16 @@
+package com.termux.app.fragments.settings;
+
+import android.content.Context;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+
+public abstract class configureTermuxPreference extends PreferenceFragmentCompat {
+    abstract Preference  findPreferenceMethod();
+    abstract void build(Context context, Preference termuxPreference );
+    final public void generate(Context context) {
+        findPreferenceMethod();
+        build(context, findPreferenceMethod());
+    }
+
+}


### PR DESCRIPTION
`configureTermuxAPIPreference()`, `configureTermuxFloatPreference()`, etc are very similar method. so Using Template method
reduces overlapped codes. At first, make abstract class