### PR TITLE
Changed: Apply Builder pattern `ExecutionCommand`

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -40,6 +40,7 @@ import com.termux.shared.notification.NotificationUtils;
 import com.termux.shared.android.PermissionUtils;
 import com.termux.shared.data.DataUtils;
 import com.termux.shared.shell.command.ExecutionCommand;
+import com.termux.shared.shell.command.ExecutionCommand.ExecutionCommandBuilder;
 import com.termux.shared.shell.command.ExecutionCommand.Runner;
 import com.termux.shared.shell.command.ExecutionCommand.SessionCreateMode;
 import com.termux.terminal.TerminalEmulator;
@@ -471,7 +472,15 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
     /** Create a TermuxTask. */
     @Nullable
     public AppShell createTermuxTask(String executablePath, String[] arguments, String stdin, String workingDirectory) {
-        return createTermuxTask(new ExecutionCommand(getNextExecutionId(), executablePath, arguments, stdin, workingDirectory, Runner.APP_SHELL.getName(), false));
+        return createTermuxTask(new ExecutionCommandBuilder()
+                                    .setID(getNextExecutionId())
+                                    .setExecutable(executablePath)
+                                    .setArguments(arguments)
+                                    .setStdin(stdin)
+                                    .setWorkingDirectory(workingDirectory)
+                                    .setRunner(Runner.APP_SHELL.getName())
+                                    .setIsFailsafe(false)
+                                    .build());
     }
 
     /** Create a TermuxTask. */
@@ -588,7 +597,15 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
      */
     @Nullable
     public TermuxSession createTermuxSession(String executablePath, String[] arguments, String stdin, String workingDirectory, boolean isFailSafe, String sessionName) {
-        ExecutionCommand executionCommand = new ExecutionCommand(getNextExecutionId(), executablePath, arguments, stdin, workingDirectory, Runner.TERMINAL_SESSION.getName(), isFailSafe);
+        ExecutionCommand executionCommand = new ExecutionCommandBuilder()
+                                                .setID(getNextExecutionId())
+                                                .setExecutable(executablePath)
+                                                .setArguments(arguments)
+                                                .setStdin(stdin)
+                                                .setWorkingDirectory(workingDirectory)
+                                                .setRunner(Runner.TERMINAL_SESSION.getName())
+                                                .setIsFailsafe(isFailSafe)
+                                                .build();
         executionCommand.sessionName = sessionName;
         return createTermuxSession(executionCommand);
     }

--- a/termux-shared/src/main/java/com/termux/shared/shell/command/ExecutionCommand.java
+++ b/termux-shared/src/main/java/com/termux/shared/shell/command/ExecutionCommand.java
@@ -249,6 +249,61 @@ public class ExecutionCommand {
         this.isFailsafe = isFailsafe;
     }
 
+    /** The {@link Class} that defines a builder for {@link ExecutionCommand} class. */
+    public static class ExecutionCommandBuilder {
+        private Integer id;
+        private String executable;
+        private String[] arguments;
+        private String stdin;
+        private String workingDirectory;
+        private String runner;
+        private boolean isFailsafe;
+
+        public ExecutionCommand.ExecutionCommandBuilder setID(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public ExecutionCommand.ExecutionCommandBuilder setExecutable(String executable) {
+            this.executable = executable;
+            return this;
+        }
+
+        public ExecutionCommand.ExecutionCommandBuilder setArguments(String[] arguments) {
+            if (arguments != null)
+                this.arguments = arguments;
+            return this;
+        }
+
+        public ExecutionCommand.ExecutionCommandBuilder setStdin(String stdin) {
+            this.stdin = stdin;
+            return this;
+        }
+
+        public ExecutionCommand.ExecutionCommandBuilder setWorkingDirectory(String workingDirectory) {
+            this.workingDirectory = workingDirectory;
+            return this;
+        }
+
+        public ExecutionCommand.ExecutionCommandBuilder setRunner(String runner) {
+            this.runner = runner;
+            return this;
+        }
+
+        public ExecutionCommand.ExecutionCommandBuilder setIsFailsafe(boolean isFailsafe) {
+            this.isFailsafe = isFailsafe;
+            return this;
+        }
+
+        /**
+         * Returns {@link ExecutionCommand} object.
+         *
+         */
+        public ExecutionCommand build() {
+            return new ExecutionCommand(id, executable, arguments, stdin, workingDirectory, runner, isFailsafe);
+        }
+
+    }
 
     public boolean isPluginExecutionCommandWithPendingResult() {
         return isPluginExecutionCommand && resultConfig.isCommandWithPendingResult();

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxUtils.java
@@ -19,6 +19,7 @@ import com.termux.shared.termux.file.TermuxFileUtils;
 import com.termux.shared.logger.Logger;
 import com.termux.shared.markdown.MarkdownUtils;
 import com.termux.shared.shell.command.ExecutionCommand;
+import com.termux.shared.shell.command.ExecutionCommand.ExecutionCommandBuilder;
 import com.termux.shared.errors.Error;
 import com.termux.shared.android.PackageUtils;
 import com.termux.shared.termux.shell.TermuxShellEnvironmentClient;
@@ -529,10 +530,13 @@ public class TermuxUtils {
         }
 
         aptInfoScript = aptInfoScript.replaceAll(Pattern.quote("@TERMUX_PREFIX@"), TermuxConstants.TERMUX_PREFIX_DIR_PATH);
-
-        ExecutionCommand executionCommand = new ExecutionCommand(1,
-            TermuxConstants.TERMUX_BIN_PREFIX_DIR_PATH + "/bash", null, aptInfoScript,
-            null, ExecutionCommand.Runner.APP_SHELL.getName(), false);
+        ExecutionCommand executionCommand = new ExecutionCommandBuilder()
+                                                .setID(1)
+                                                .setExecutable(TermuxConstants.TERMUX_BIN_PREFIX_DIR_PATH + "/bash")
+                                                .setStdin(aptInfoScript)
+                                                .setRunner(ExecutionCommand.Runner.APP_SHELL.getName())
+                                                .setIsFailsafe(false)
+                                                .build();
         executionCommand.commandLabel = "APT Info Command";
         executionCommand.backgroundCustomLogLevel = Logger.LOG_LEVEL_OFF;
         AppShell appShell = AppShell.execute(context, executionCommand, null, new TermuxShellEnvironmentClient(), true);
@@ -590,8 +594,14 @@ public class TermuxUtils {
 
         // Run script
         // Logging must be disabled for output of logcat command itself in StreamGobbler
-        ExecutionCommand executionCommand = new ExecutionCommand(1, "/system/bin/sh",
-            null, logcatScript + "\n", "/", ExecutionCommand.Runner.APP_SHELL.getName(), true);
+        ExecutionCommand executionCommand = new ExecutionCommandBuilder()
+                                                .setID(1)
+                                                .setExecutable("/system/bin/sh")
+                                                .setStdin(logcatScript + "\n")
+                                                .setWorkingDirectory("/")
+                                                .setRunner(ExecutionCommand.Runner.APP_SHELL.getName())
+                                                .setIsFailsafe(true)
+                                                .build();
         executionCommand.commandLabel = "Logcat dump command";
         executionCommand.backgroundCustomLogLevel = Logger.LOG_LEVEL_OFF;
         AppShell appShell = AppShell.execute(context, executionCommand, null, new TermuxShellEnvironmentClient(), true);

--- a/termux-shared/src/main/java/com/termux/shared/termux/file/TermuxFileUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/file/TermuxFileUtils.java
@@ -358,8 +358,14 @@ public class TermuxFileUtils {
     }
 
     private static ExecutionCommand runningScript(StringBuilder statScript, Context context) {
-        ExecutionCommand executionCommand = new ExecutionCommand(1, "/system/bin/sh", null,
-            statScript.toString() + "\n", "/", ExecutionCommand.Runner.APP_SHELL.getName(), true);
+        ExecutionCommand executionCommand = new ExecutionCommand.ExecutionCommandBuilder()
+                                                .setID(1)
+                                                .setExecutable("/system/bin/sh")
+                                                .setStdin(statScript.toString() + "\n")
+                                                .setWorkingDirectory("/")
+                                                .setRunner(ExecutionCommand.Runner.APP_SHELL.getName())
+                                                .setIsFailsafe(true)
+                                                .build();
         executionCommand.commandLabel = TermuxConstants.TERMUX_APP_NAME + " Files Stat Command";
         executionCommand.backgroundCustomLogLevel = Logger.LOG_LEVEL_OFF;
         AppShell appShell = AppShell.execute(context, executionCommand, null, new TermuxShellEnvironmentClient(), true);


### PR DESCRIPTION
Makes constructor calls more readable and easy.
Also, there's no need to pass null parameter.